### PR TITLE
Remove leak from unittest

### DIFF
--- a/prbt_support/test/urdf_tests.cpp
+++ b/prbt_support/test/urdf_tests.cpp
@@ -66,7 +66,7 @@ protected:
   // ros stuff
   ros::NodeHandle ph_ {"~"};
   robot_model::RobotModelConstPtr robot_model_ {
-    robot_model_loader::RobotModelLoader(GetParam()).getModel()};
+    robot_model_loader::RobotModelLoader(GetParam(), false).getModel()};
 
   // parameters
   std::string group_name_, tip_link_name_;


### PR DESCRIPTION
I think I found your leak.
Please retest.

I had this issue before, 
https://github.com/PilzDE/pilz_robots/blob/17708c02ec086ec1647ec80958e73633e7b51d64/pilz_control/include/pilz_control/cartesian_speed_monitor.h#L38 

yet currently I cannot remember in detail what the issue was :man_shrugging: 

I think it was something related to the MultiLibraryLoader...
https://github.com/ros/class_loader/blob/melodic-devel/include/class_loader/multi_library_class_loader.hpp

greetings
